### PR TITLE
Reset viz context after user event to resolve Chrome autoplay policy

### DIFF
--- a/public/javascripts/sketch.js
+++ b/public/javascripts/sketch.js
@@ -667,6 +667,8 @@ function stopAll() {
 function initEventListeners() {
   window.addEventListener('resize', setCanvasDimensions);
   window.addEventListener('keydown', (event) => {
+    getAudioContext().resume();
+    
     const keyCode = event.keyCode;
     const button = document.querySelector(`.soundTriggerContainer button[data-char-code="${keyCode}"]`);
 


### PR DESCRIPTION
Chrome instituted a new autoplay policy that prevents p5 sketches from animating. Resetting the audio context on the UI event frees it up.